### PR TITLE
:sparkles: : editable variables

### DIFF
--- a/src/main/java/io/codeka/gaia/bo/TerraformVariable.java
+++ b/src/main/java/io/codeka/gaia/bo/TerraformVariable.java
@@ -1,5 +1,8 @@
 package io.codeka.gaia.bo;
 
+/**
+ * Represents a module variable
+ */
 public class TerraformVariable {
 
     private String name;
@@ -7,6 +10,8 @@ public class TerraformVariable {
     private String description;
 
     private String defaultValue;
+
+    private boolean editable;
 
     public String getName() {
         return name;
@@ -30,5 +35,13 @@ public class TerraformVariable {
 
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -3417,3 +3417,11 @@ pre[class*="language-"] {
 code[class*="language-"] b {
     font-weight: bold;
 }
+
+.form-check{
+    margin-bottom: 0.5rem;
+}
+.form-check-input{
+    margin-top: 0;
+    margin-left: -1.5rem;
+}

--- a/src/main/resources/templates/module.html
+++ b/src/main/resources/templates/module.html
@@ -75,19 +75,26 @@
                 <h2>Variables <button type="button" class="btn btn-success" @click="addVar()">+</button></h2>
 
                 <div class="form-row align-items-end" v-for="(modVar,modVarIdx) in variables">
-                    <div class="form-group col-md-4" >
+                    <div class="form-group col-md-3" >
                         <label for="var-name">Name: </label>
                         <input type="text" class="form-control" id="var-name" v-model="modVar.name">
                     </div>
-                    <div class="form-group col-md-4" >
+                    <div class="form-group col-md-3" >
                         <label for="var-description">Description: </label>
                         <input type="text" class="form-control" id="var-description" v-model="modVar.description">
                     </div>
-                    <div class="form-group col-md-3" >
+                    <div class="form-group col-md-2" >
                         <label for="var-defaultValue">Default value: </label>
                         <input type="text" class="form-control" id="var-defaultValue" v-model="modVar.defaultValue">
                     </div>
-                    <div class="form-group col-md-1" >
+                    <div class="form-group col-md-1">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" :id="'check-' + modVarIdx" v-model="modVar.editable">
+                            <label class="form-check-label" :for="'check-' + modVarIdx"
+                                   data-toggle="tooltip" data-placement="top" title="Set this variable as editable for module users">Editable</label>
+                        </div>
+                    </div>
+                    <div class="form-group" >
                         <button type="button" class="form-control btn btn-danger" @click="removeVar(modVarIdx)">-</button>
                     </div>
                 </div>
@@ -132,7 +139,8 @@
                         data.variables.push({});
                     }
                 }
-            })
+            });
+            $('[data-toggle="tooltip"]').tooltip();
         });
 </script>
 

--- a/src/main/resources/templates/stack.html
+++ b/src/main/resources/templates/stack.html
@@ -164,12 +164,15 @@
                         <small>This is the configuration of your module's variables !</small>
                     </div>
                     <div class="block_content">
-                        <div class="form-row align-items-end" v-for="(modVar,modVarIdx) in stack.module.variables">
-                            <div class="form-group col-md-4" >
+                        <div class="form-row align-items-end" v-for="(modVar,modVarIdx) in editableVars" v-if="editableVars.length > 0">
+                            <div class="form-group col">
                                 <label for="var-name">{{modVar.name}}: </label>
                                 <input type="text" class="form-control" id="var-name" v-model="stack.variableValues[modVar.name]" @change="recomputeState">
                                 <small id="emailHelp" class="form-text text-muted">{{modVar.description}}</small>
                             </div>
+                        </div>
+                        <div v-if="editableVars.length === 0">
+                            <p>No editable variable defined for this module.</p>
                         </div>
                     </div>
                 </div>
@@ -270,6 +273,11 @@
                     if(stack.state === "RUNNING"){
                         stack.state = "TO_UPDATE";
                     }
+                }
+            },
+            computed: {
+                editableVars: function() {
+                    return this.stack.module.variables.filter(variable => variable.editable);
                 }
             }
         });


### PR DESCRIPTION
Some variables could be made "unmodifiable" by module users.
To do so, add a switch or a checkbox in the module definition, next to each variables in the module edit view.
Then in the stack view, the variable MUST not be visible or editable by users.

resolves #5